### PR TITLE
Add audio support for Core Desktop

### DIFF
--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -59,6 +59,8 @@ owner /{,var/}run/pulse/native rwk,
 owner /{,var/}run/pulse/pid r,
 owner /{,var/}run/user/[0-9]*/ r,
 owner /{,var/}run/user/[0-9]*/pulse/ rw,
+owner /{,var/}run/user/[0-9]*/pulse/native rwk,
+owner /{,var/}run/user/[0-9]*/pulse/pid r,
 
 /run/udev/data/c116:[0-9]* r,
 /run/udev/data/+sound:card[0-9]* r,
@@ -138,6 +140,7 @@ func (iface *audioPlaybackInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              audioPlaybackSummary,
 		ImplicitOnClassic:    true,
+		ImplicitOnCore:       true,
 		BaseDeclarationSlots: audioPlaybackBaseDeclarationSlots,
 	}
 }

--- a/interfaces/builtin/audio_record.go
+++ b/interfaces/builtin/audio_record.go
@@ -64,6 +64,7 @@ func (iface *audioRecordInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              audioRecordSummary,
 		ImplicitOnClassic:    true,
+		ImplicitOnCore:       true,
 		BaseDeclarationSlots: audioRecordBaseDeclarationSlots,
 	}
 }


### PR DESCRIPTION
This is one of the three MRs required for adding audio support to Core Desktop. This one adds the audio-playback and audio-record slots to snapd.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
