### PR TITLE
UCD-100: allow local user account management

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -39,6 +39,44 @@ const accountControlBaseDeclarationSlots = `
 `
 
 const accountControlConnectedPlugAppArmor = `
+#include <abstractions/dbus-strict>
+
+# Introspection of org.freedesktop.Accounts
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/Accounts{,/User[0-9]*}
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect,
+
+dbus (send)
+    bus=system
+    path=/org/freedesktop/Accounts
+    interface=org.freedesktop.Accounts
+    peer=(label=unconfined),
+
+dbus (send)
+    bus=system
+    path=/org/freedesktop/Accounts/User[0-9]*
+    interface=org.freedesktop.Accounts.User
+    peer=(label=unconfined),
+
+# Read all properties from Accounts
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/Accounts{,/User[0-9]*}
+    interface=org.freedesktop.DBus.Properties
+    member=Get{,All},
+
+# Receive Accounts property changed events
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/Accounts{,/User[0-9]*}
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
 /{,usr/}sbin/chpasswd ixr,
 /{,usr/}sbin/user{add,del} ixr,
 


### PR DESCRIPTION
This MR adds support for adding, removing and modifying the users. It also requires another patch in ubuntu-desktop-session.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
