### PR TITLE
UDENG-418: allow access to pipewire socket

### DIFF
--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -78,7 +78,7 @@ const audioPlaybackConnectedPlugAppArmorDesktop = `
 /etc/pulse/** r,
 owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
-owner /{,var/}run/user/*/pulse/ rwk,
+owner /{,var/}run/user/*/pulse/ rk,
 owner /{,var/}run/user/*/pulse/native rwk,
 owner /{,var/}run/user/*/pulse/pid r,
 `

--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -188,7 +188,7 @@ func (iface *audioPlaybackInterface) UDevPermanentSlot(spec *udev.Specification,
 
 func (iface *audioPlaybackInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(audioPlaybackPermanentSlotAppArmor)
-	if !release.OnClassic {
+	if !implicitSystemPermanentSlot(slot) {
 		// This allows to share screen in Core Desktop
 		spec.AddSnippet(audioPlaybackPermanentSlotAppArmorCore)
 	}

--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -60,7 +60,7 @@ owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,
 owner /{,var/}run/pulse/pid r,
 owner /{,var/}run/user/[0-9]*/ r,
-owner /{,var/}run/user/[0-9]*/pulse/ rw,
+owner /{,var/}run/user/[0-9]*/pulse/ r,
 owner /{,var/}run/user/[0-9]*/pulse/native rwk,
 owner /{,var/}run/user/[0-9]*/pulse/pid r,
 

--- a/interfaces/builtin/audio_playback_test.go
+++ b/interfaces/builtin/audio_playback_test.go
@@ -136,6 +136,10 @@ func (s *AudioPlaybackInterfaceSuite) TestSecCompOnClassic(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shmctl\n")
 
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/ r,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/native rwk,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/pid r,\n")
+
 	// connected classic slot to plug
 	spec = &seccomp.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.classicSlot), IsNil)
@@ -145,6 +149,9 @@ func (s *AudioPlaybackInterfaceSuite) TestSecCompOnClassic(c *C) {
 	spec = &seccomp.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.classicSlotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), HasLen, 0)
+	c.Assert(spec.SnippetForTag("snap.audio-playback.app1"), Not(testutil.Contains), "owner /run/user/[0-9]*/pipewire-[0-9] rwk,\n")
+	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), Not(testutil.Contains), "/etc/pulse/ r,\n")
+	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), Not(testutil.Contains), "/etc/pulse/** r,\n")
 }
 
 func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
@@ -156,6 +163,9 @@ func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/ r,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/native rwk,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/pid r,\n")
 
 	// connected core slot to plug
 	spec = &apparmor.Specification{}
@@ -167,6 +177,9 @@ func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
 	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.audio-playback.app1"})
 	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "capability setuid,\n")
+	c.Assert(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rwk,\n")
+	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "/etc/pulse/ r,\n")
+	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "/etc/pulse/** r,\n")
 }
 
 func (s *AudioPlaybackInterfaceSuite) TestAppArmorOnClassic(c *C) {

--- a/interfaces/builtin/audio_record.go
+++ b/interfaces/builtin/audio_record.go
@@ -64,6 +64,7 @@ func (iface *audioRecordInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              audioRecordSummary,
 		ImplicitOnClassic:    true,
+		ImplicitOnCore:       false,
 		BaseDeclarationSlots: audioRecordBaseDeclarationSlots,
 	}
 }

--- a/interfaces/builtin/audio_record.go
+++ b/interfaces/builtin/audio_record.go
@@ -64,7 +64,6 @@ func (iface *audioRecordInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              audioRecordSummary,
 		ImplicitOnClassic:    true,
-		ImplicitOnCore:       true,
 		BaseDeclarationSlots: audioRecordBaseDeclarationSlots,
 	}
 }

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -20,6 +20,8 @@
 package builtin
 
 import (
+	"strings"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -67,6 +69,12 @@ owner @{HOME}/.config/pulse/cookie rk,
 owner /{,var/}run/user/*/pulse/ rwk,
 owner /{,var/}run/user/*/pulse/native rwk,
 owner /{,var/}run/user/*/pulse/pid r,
+`
+
+const pulseaudioConnectedPlugAppArmorCore = `
+owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/ r,
+owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/native rwk,
+owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/pid r,
 `
 
 const pulseaudioConnectedPlugSecComp = `
@@ -151,6 +159,12 @@ func (iface *pulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 	spec.AddSnippet(pulseaudioConnectedPlugAppArmor)
 	if release.OnClassic {
 		spec.AddSnippet(pulseaudioConnectedPlugAppArmorDesktop)
+	}
+	if !implicitSystemConnectedSlot(slot) {
+		old := "###PLUG_SECURITY_TAGS###"
+		new := "snap." + slot.Snap().InstanceName() // forms the snap-instance-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
+		snippet := strings.Replace(pulseaudioConnectedPlugAppArmorCore, old, new, -1)
+		spec.AddSnippet(snippet)
 	}
 	return nil
 }

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -66,7 +66,7 @@ const pulseaudioConnectedPlugAppArmorDesktop = `
 /etc/pulse/** r,
 owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
-owner /{,var/}run/user/*/pulse/ rwk,
+owner /{,var/}run/user/*/pulse/ rk,
 owner /{,var/}run/user/*/pulse/native rwk,
 owner /{,var/}run/user/*/pulse/pid r,
 `


### PR DESCRIPTION
This MR is a first proposal to allow access to the pipewire socket from snapped applications. It follows the same idea used for the Wayland socket, which consists on allow to access any file placed at /run/user/XXXXX/YYYYY/pulseaudio.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
