### PR TITLE
UDENG-434: Add support for audio-playback in snapctl2

### DIFF
--- a/overlord/hookstate/ctlcmd/is_connected.go
+++ b/overlord/hookstate/ctlcmd/is_connected.go
@@ -71,7 +71,8 @@ codes may be returned: 10 if the other snap is not connected but uses
 classic confinement, or 11 if the other process is not snap confined.
 
 The --pid and --apparmor-label options may only be used with slots of
-interface type "pulseaudio", "audio-record", or "cups-control".
+interface type "pulseaudio", "audio-playback", "audio-record", or
+"cups-control".
 `)
 
 func init() {
@@ -84,7 +85,7 @@ func isConnectedPidCheckAllowed(info *snap.Info, plugOrSlot string) bool {
 	slot := info.Slots[plugOrSlot]
 	if slot != nil {
 		switch slot.Interface {
-		case "pulseaudio", "audio-record", "cups-control":
+		case "pulseaudio", "audio-record", "audio-playback", "cups-control":
 			return true
 		}
 	}


### PR DESCRIPTION
Snapctl2 call allows to check from inside a snap if another snap has connected any of the "cups-control", "audio-record" or "pulseaudio" interfaces.

For the pipewire support, it would be a good idea to also have access to the "audio-playback" interface, because, although it is allowed by default and connected automatically, if an user manually disconnects it, that wouldn't be honored in pipewire.

This patch does this.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
