### PR TITLE
UCD-115: limit access to local wayland sockets

### DIFF
--- a/interfaces/builtin/desktop_launch.go
+++ b/interfaces/builtin/desktop_launch.go
@@ -42,6 +42,13 @@ const desktopLaunchConnectedPlugAppArmor = `
 /var/lib/snapd/desktop/applications/{,*} r,
 /var/lib/snapd/desktop/icons/{,**} r,
 
+# Allow to execute snap commands.
+/snap/bin/* ixr,
+
+# Allow to execute the snap command, which is used to launch each application
+/usr/bin/snap ixr,
+/snap/snapd/*/usr/bin/snap ixr,
+
 # Allow access to all snap metadata
 /snap/*/*/** r,
 

--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -107,7 +107,7 @@ owner /{dev,run}/shm/###PLUG_SECURITY_TAGS###.wayland.mozilla.ipc.[0-9]* rw,
 
 const waylandConnectedPlugAppArmor = `
 # Allow access to the Wayland compositor server socket
-owner /run/user/[0-9]*/wayland-[0-9]* rw,
+owner /run/user/[0-9]*/{,*/}wayland-[0-9]* rw,
 
 # Needed when using QT_QPA_PLATFORM=wayland-egl (MESA dri config)
 /etc/drirc r,

--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -107,7 +107,7 @@ owner /{dev,run}/shm/###PLUG_SECURITY_TAGS###.wayland.mozilla.ipc.[0-9]* rw,
 
 const waylandConnectedPlugAppArmor = `
 # Allow access to the Wayland compositor server socket
-owner /run/user/[0-9]*/{,*/}wayland-[0-9]* rw,
+owner /run/user/[0-9]*/wayland-[0-9]* rw,
 
 # Needed when using QT_QPA_PLATFORM=wayland-egl (MESA dri config)
 /etc/drirc r,
@@ -128,6 +128,7 @@ func (iface *waylandInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              waylandSummary,
 		ImplicitOnClassic:    true,
+		ImplicitOnCore:       false,
 		BaseDeclarationSlots: waylandBaseDeclarationSlots,
 	}
 }

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -127,7 +127,7 @@ func (s *WaylandInterfaceSuite) TestAppArmorSpecOnClassic(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/wayland-[0-9]* rw,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/{,*/}wayland-[0-9]* rw,")
 
 	// connected classic slot to plug
 	spec = &apparmor.Specification{}


### PR DESCRIPTION
To allow any program to get access to the Wayland socket in Ubuntu Core Desktop, no matter if it is running inside or outside a snap, a hard link is made from the real socket (located at /run/user/XXXX/snap.ubuntu-desktop-session/wayland-0) to the expected place (/run/user/XXXX/wayland-0).

Unfortunately, due to the way AppArmor works, it is able to detect that, although a snapped program is accessing the global path, it really is trying to access the socket in the local path, something that, by default, is forbidden.

Currently this is solved with this AppArmor rule:

    owner /run/user/[0-9]*/{,*/}wayland-[0-9]* rw,

This rule has the problem that it allows any snap to access any wayland-X file/socket located inside the private XDG folder of any other snap, which is a security breach (for example, it allows two apparently unrelated snaps to communicate between them without any kind of control).

The solution presented in this patch consists on allowing to access only to the socket placed in the folder of the snap that is implementing the wayland slot.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
