### PR TITLE
o/restart: Don't automatically restart on a core desktop system

### DIFF
--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -314,7 +314,7 @@ func FinishTaskWithRestart(task *state.Task, status state.Status, rt RestartType
 	// instead or just log the request if we are on the undo path
 	switch rt {
 	case RestartSystem, RestartSystemNow:
-		if release.OnClassic {
+		if release.OnClassic || release.OnCoreDesktop {
 			if status == state.DoneStatus {
 				rm := restartManager(task.State(), "internal error: cannot request a restart before RestartManager initialization")
 				// notify the system that a reboot is required

--- a/release/release.go
+++ b/release/release.go
@@ -181,6 +181,9 @@ func SystemctlSupportsUserUnits() bool {
 // classic Ubuntu system or a native Ubuntu Core image.
 var OnClassic bool
 
+// OnCoreDesktop states whether the process is running inside a Core Desktop image.
+var OnCoreDesktop bool
+
 // OnWSL states whether the process is running inside the Windows
 // Subsystem for Linux
 var OnWSL bool
@@ -196,6 +199,10 @@ func init() {
 	ReleaseInfo = readOSRelease()
 
 	OnClassic = (ReleaseInfo.ID != "ubuntu-core")
+
+	// We don't currently have a method of determining if we're on core desktop.
+	// This will be added later, hard code it for now (this branch only used on core desktop).
+	OnCoreDesktop = true
 
 	WSLVersion = getWSLVersion()
 	OnWSL = WSLVersion != 0


### PR DESCRIPTION
Make core desktop behave like a classic system and don't automatically do reboots.