### PR TITLE
interfaces: add access to files necessary for xdg-user-dirs to the desktop slot

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -335,6 +335,9 @@ dbus (receive, send)
     path=/org/freedesktop/portal/desktop{,/**}
     interface=org.freedesktop.DBus.Properties
     peer=(label=unconfined),
+
+/etc/xdg/user-dirs.conf r,
+/etc/xdg/user-dirs.defaults r,
 `
 
 type desktopInterface struct {


### PR DESCRIPTION
add access to files necessary for xdg-user-dirs to the desktop slot

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
