### PR TITLE
Fix opening links from GTK from inside the desktop session

### DIFF
--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -209,7 +209,7 @@ func (s *Launcher) OpenURL(addr string, sender dbus.Sender) *dbus.Error {
 	// this code must not add directories from the snap
 	// to XDG_DATA_DIRS and similar, see
 	// https://ubuntu.com/security/CVE-2020-11934
-	if err := exec.Command("xdg-open", addr).Run(); err != nil {
+	if err := exec.Command("xdg-open-original", addr).Run(); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("cannot open supplied URL"))
 	}
 
@@ -295,7 +295,7 @@ func (s *Launcher) OpenFile(parentWindow string, clientFd dbus.UnixFD, sender db
 		return dbus.MakeFailedError(fmt.Errorf("permission denied"))
 	}
 
-	if err = exec.Command("xdg-open", filename).Run(); err != nil {
+	if err = exec.Command("xdg-open-original", filename).Run(); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("cannot open supplied URL"))
 	}
 

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -209,7 +209,11 @@ func (s *Launcher) OpenURL(addr string, sender dbus.Sender) *dbus.Error {
 	// this code must not add directories from the snap
 	// to XDG_DATA_DIRS and similar, see
 	// https://ubuntu.com/security/CVE-2020-11934
-	if err := exec.Command("xdg-open-original", addr).Run(); err != nil {
+	command := "xdg-open"
+	if err := checkOnClassic(); err != nil {
+		command = "xdg-open-original"
+	}
+	if err := exec.Command(command, addr).Run(); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("cannot open supplied URL"))
 	}
 
@@ -295,7 +299,11 @@ func (s *Launcher) OpenFile(parentWindow string, clientFd dbus.UnixFD, sender db
 		return dbus.MakeFailedError(fmt.Errorf("permission denied"))
 	}
 
-	if err = exec.Command("xdg-open-original", filename).Run(); err != nil {
+	command := "xdg-open"
+	if err := checkOnClassic(); err != nil {
+		command = "xdg-open-original"
+	}
+	if err = exec.Command(command, filename).Run(); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("cannot open supplied URL"))
 	}
 


### PR DESCRIPTION
This is one of two patches to allow to open links from GTK inside the desktop session. This one changes the script to be used from snapd from xdg-open to xdg-open-original. This way, all programs will call xdg-open, which, through DBus, will invoke xdg-open-original.

This patch requires https://github.com/canonical/core-base-desktop/pull/25

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
