### PR TITLE
priviledgedDesktopLauncher: support parameters

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -234,7 +234,7 @@ func (x *cmdRun) Execute(args []string) error {
 			return fmt.Errorf(i18n.G("unable to access privileged desktop launcher: unable unable to get session bus: %v"), err)
 		}
 		o := conn.Object("io.snapcraft.Launcher", "/io/snapcraft/PrivilegedDesktopLauncher")
-		call := o.Call("io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntryWithParameters", 0, desktopFile, args)
+		call := o.Call("io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntryWithArguments", 0, desktopFile, args)
 		if call.Err != nil {
 			return fmt.Errorf(i18n.G("failed to launch %s via the privileged desktop launcher: %v"), desktopFile, call.Err)
 		}

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -234,7 +234,7 @@ func (x *cmdRun) Execute(args []string) error {
 			return fmt.Errorf(i18n.G("unable to access privileged desktop launcher: unable unable to get session bus: %v"), err)
 		}
 		o := conn.Object("io.snapcraft.Launcher", "/io/snapcraft/PrivilegedDesktopLauncher")
-		call := o.Call("io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntry", 0, desktopFile)
+		call := o.Call("io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntryWithParameters", 0, desktopFile, args)
 		if call.Err != nil {
 			return fmt.Errorf(i18n.G("failed to launch %s via the privileged desktop launcher: %v"), desktopFile, call.Err)
 		}

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -234,7 +234,7 @@ func (x *cmdRun) Execute(args []string) error {
 			return fmt.Errorf(i18n.G("unable to access privileged desktop launcher: unable unable to get session bus: %v"), err)
 		}
 		o := conn.Object("io.snapcraft.Launcher", "/io/snapcraft/PrivilegedDesktopLauncher")
-		call := o.Call("io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntryWithArguments", 0, desktopFile, args)
+		call := o.Call("io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntry2", 0, desktopFile, "", args, make(map[string]string))
 		if call.Err != nil {
 			return fmt.Errorf(i18n.G("failed to launch %s via the privileged desktop launcher: %v"), desktopFile, call.Err)
 		}

--- a/interfaces/builtin/desktop_launch.go
+++ b/interfaces/builtin/desktop_launch.go
@@ -59,7 +59,7 @@ dbus (send)
     bus=session
     path=/io/snapcraft/PrivilegedDesktopLauncher
     interface=io.snapcraft.PrivilegedDesktopLauncher
-    member=OpenDesktopEntry
+    member="OpenDesktopEntry{,WithParameters}"
     peer=(label=unconfined),
 `
 

--- a/interfaces/builtin/desktop_launch.go
+++ b/interfaces/builtin/desktop_launch.go
@@ -59,7 +59,7 @@ dbus (send)
     bus=session
     path=/io/snapcraft/PrivilegedDesktopLauncher
     interface=io.snapcraft.PrivilegedDesktopLauncher
-    member="OpenDesktopEntry{,WithArguments}"
+    member="{OpenDesktopEntry,OpenDesktopEntry2}"
     peer=(label=unconfined),
 `
 

--- a/interfaces/builtin/desktop_launch.go
+++ b/interfaces/builtin/desktop_launch.go
@@ -59,7 +59,7 @@ dbus (send)
     bus=session
     path=/io/snapcraft/PrivilegedDesktopLauncher
     interface=io.snapcraft.PrivilegedDesktopLauncher
-    member="OpenDesktopEntry{,WithParameters}"
+    member="OpenDesktopEntry{,WithArguments}"
     peer=(label=unconfined),
 `
 

--- a/tests/main/interfaces-desktop-launch/test-launcher/bin/dbus.sh
+++ b/tests/main/interfaces-desktop-launch/test-launcher/bin/dbus.sh
@@ -2,5 +2,5 @@
 
 exec dbus-send --session --print-reply \
     --dest=io.snapcraft.Launcher /io/snapcraft/PrivilegedDesktopLauncher \
-    io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntryWithArguments \
-    string:"$1" array:string:"$2"
+    io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntry2 \
+    string:"$1" string:"" array:string:"$2" {}

--- a/tests/main/interfaces-desktop-launch/test-launcher/bin/dbus.sh
+++ b/tests/main/interfaces-desktop-launch/test-launcher/bin/dbus.sh
@@ -2,5 +2,5 @@
 
 exec dbus-send --session --print-reply \
     --dest=io.snapcraft.Launcher /io/snapcraft/PrivilegedDesktopLauncher \
-    io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntry \
-    string:"$1"
+    io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntryWithParameters \
+    string:"$1" array:string:"$2"

--- a/tests/main/interfaces-desktop-launch/test-launcher/bin/dbus.sh
+++ b/tests/main/interfaces-desktop-launch/test-launcher/bin/dbus.sh
@@ -2,5 +2,5 @@
 
 exec dbus-send --session --print-reply \
     --dest=io.snapcraft.Launcher /io/snapcraft/PrivilegedDesktopLauncher \
-    io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntryWithParameters \
+    io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntryWithArguments \
     string:"$1" array:string:"$2"

--- a/usersession/userd/export_test.go
+++ b/usersession/userd/export_test.go
@@ -46,3 +46,5 @@ func MockRegularFileExists(f func(string) (bool, bool, error)) func() {
 		regularFileExists = old
 	}
 }
+
+var ArgumentsSecurityCheck = argumentsSecurityCheck

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -138,17 +138,17 @@ func (s *PrivilegedDesktopLauncher) OpenDesktopEntry2(desktopFileID string, acti
 func argumentsSecurityCheck(arguments []string) error {
 	for _, arg := range arguments {
 		if arg == "" {
-			return fmt.Errorf("Passed an empty parameter")
+			return fmt.Errorf("passed an empty parameter")
 		}
 		uri, err := url.Parse(arg)
 		if err != nil {
-			return fmt.Errorf("One of the parameters is not an URI: %s", arg)
+			return fmt.Errorf("one of the parameters is not an URI: %s", arg)
 		}
-		if uri.Path == "" {
-			return fmt.Errorf("Passed an empty URI: %s", arg)
+		if uri.Host == "" && uri.Path == "" {
+			return fmt.Errorf("passed an empty URI: %s", arg)
 		}
 		if (uri.Scheme == "file") && (uri.Path[0] != '/') {
-			return fmt.Errorf("Passed a file URI with a relative path: %s", arg)
+			return fmt.Errorf("passed a file URI with a relative path: %s", arg)
 		}
 	}
 	return nil

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -100,6 +100,10 @@ func (s *PrivilegedDesktopLauncher) OpenDesktopEntry2(desktopFileID string, acti
 		return dbus.MakeFailedError(err)
 	}
 
+	if len(environment) != 0 {
+		return dbus.MakeFailedError(fmt.Errorf("unknown variables in environment"))
+	}
+
 	command, icon, err := readExecCommandFromDesktopFile(desktopFile, action)
 	if err != nil {
 		return dbus.MakeFailedError(err)

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -79,8 +79,7 @@ func (s *PrivilegedDesktopLauncher) IntrospectionData() string {
 // DBus interface. The desktopFileID is described here:
 // https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id
 func (s *PrivilegedDesktopLauncher) OpenDesktopEntry(desktopFileID string, sender dbus.Sender) *dbus.Error {
-	arguments := make([]string, 0)
-	return s.OpenDesktopEntryWithArguments(desktopFileID, arguments, sender)
+	return s.OpenDesktopEntryWithArguments(desktopFileID, nil, sender)
 }
 
 func (s *PrivilegedDesktopLauncher) OpenDesktopEntryWithArguments(desktopFileID string, arguments []string, sender dbus.Sender) *dbus.Error {
@@ -133,6 +132,9 @@ func (s *PrivilegedDesktopLauncher) OpenDesktopEntryWithArguments(desktopFileID 
 // argumentsSecurityCheck ensures that none of the arguments passed
 // by begins with "-", to avoid passing parameters to the application.
 func argumentsSecurityCheck(arguments []string) error {
+	if arguments == nil {
+		return nil
+	}
 	for i := 0; i < len(arguments); i++ {
 		if arguments[i][0] == '-' {
 			return fmt.Errorf("passed a parameter as argument: %s", arguments[i])
@@ -314,9 +316,13 @@ func parseExecCommand(command string, icon string, arguments []string) ([]string
 		} else if strings.HasPrefix(arg, "%") {
 			switch arg {
 			case "%f", "%u":
-				args = append(args, arguments[0])
+				if (arguments != nil) && (len(arguments) > 0) {
+					args = append(args, arguments[0])
+				}
 			case "%F", "%U":
-				args = append(args, arguments...)
+				if (arguments != nil) && (len(arguments) > 0) {
+					args = append(args, arguments...)
+				}
 			case "%i":
 				args = append(args, "--icon", icon)
 			default:

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -340,9 +340,7 @@ func parseExecCommand(command string, icon string, uris []string) ([]string, err
 					args = append(args, uris[0])
 				}
 			case "%U":
-				if (uris != nil) && (len(uris) > 0) {
-					args = append(args, uris...)
-				}
+				args = append(args, uris...)
 			case "%f":
 				if (uris != nil) && (len(uris) > 0) {
 					uri, _ := url.Parse(uris[0])
@@ -353,7 +351,7 @@ func parseExecCommand(command string, icon string, uris []string) ([]string, err
 				}
 			case "%F":
 				if (uris != nil) && (len(uris) > 0) {
-					for uri := range uris {
+					for _, uri := range uris {
 						uri_parsed, _ := url.Parse(uris[0])
 						if uri_parsed.Scheme != "file" {
 							return nil, fmt.Errorf("cannot run %q because it expects files, but a non-file URI (%q) was passed", command, uri)

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -144,11 +144,16 @@ func argumentsSecurityCheck(arguments []string) error {
 		if err != nil {
 			return fmt.Errorf("one of the parameters is not an URI: %s", arg)
 		}
-		if uri.Host == "" && uri.Path == "" {
-			return fmt.Errorf("passed an empty URI: %s", arg)
+		if !uri.IsAbs() {
+			return fmt.Errorf("passed a non-absolute URI: %s", arg)
 		}
-		if (uri.Scheme == "file") && (uri.Host != "" || uri.Path[0] != '/') {
-			return fmt.Errorf("passed a file URI with a relative path: %s", arg)
+		if uri.Scheme == "file" {
+			if uri.Host != "" {
+				return fmt.Errorf("passed a file URI with a non-empty host: %s", arg)
+			}
+			if !filepath.IsAbs(uri.Path) {
+				return fmt.Errorf("passed a file URI with a relative path: %s", arg)
+			}
 		}
 	}
 	return nil

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -147,7 +147,7 @@ func argumentsSecurityCheck(arguments []string) error {
 		if uri.Host == "" && uri.Path == "" {
 			return fmt.Errorf("passed an empty URI: %s", arg)
 		}
-		if (uri.Scheme == "file") && (uri.Path[0] != '/') {
+		if (uri.Scheme == "file") && (uri.Host != "" || uri.Path[0] != '/') {
 			return fmt.Errorf("passed a file URI with a relative path: %s", arg)
 		}
 	}

--- a/usersession/userd/privileged_desktop_launcher_internal_test.go
+++ b/usersession/userd/privileged_desktop_launcher_internal_test.go
@@ -501,7 +501,7 @@ func (s *privilegedDesktopLauncherInternalSuite) TestParseExecCommandSucceedsWit
 	}
 
 	for _, test := range testCases {
-		actual, err := userd.ParseExecCommand(test.cmd, "/snap/chromium/1193/chromium.png")
+		actual, err := userd.ParseExecCommand(test.cmd, "/snap/chromium/1193/chromium.png", nil)
 		comment := Commentf("cmd=%s", test.cmd)
 		c.Check(err, IsNil, comment)
 		c.Check(actual, DeepEquals, test.expect, comment)

--- a/usersession/userd/privileged_desktop_launcher_internal_test.go
+++ b/usersession/userd/privileged_desktop_launcher_internal_test.go
@@ -523,7 +523,7 @@ func (s *privilegedDesktopLauncherInternalSuite) TestParseExecCommandFailsWithIn
 	}
 
 	for _, test := range testCases {
-		_, err := userd.ParseExecCommand(test.cmd, "/snap/chromium/1193/chromium.png")
+		_, err := userd.ParseExecCommand(test.cmd, "/snap/chromium/1193/chromium.png", nil)
 		comment := Commentf("cmd=%s", test.cmd)
 		c.Check(err, ErrorMatches, test.err, comment)
 	}

--- a/usersession/userd/privileged_desktop_launcher_internal_test.go
+++ b/usersession/userd/privileged_desktop_launcher_internal_test.go
@@ -537,7 +537,7 @@ func (s *privilegedDesktopLauncherInternalSuite) testReadExecCommandFromDesktopF
 	err := ioutil.WriteFile(desktopFile, []byte(fileContent), 0644)
 	c.Assert(err, IsNil)
 
-	exec, icon, err := userd.ReadExecCommandFromDesktopFile(desktopFile)
+	exec, icon, err := userd.ReadExecCommandFromDesktopFile(desktopFile, "")
 	c.Assert(err, IsNil)
 
 	c.Check(exec, Equals, fmt.Sprintf("env BAMF_DESKTOP_FILE_HINT=%s %s/chromium %%U", desktopFile, dirs.SnapBinariesDir))
@@ -571,7 +571,7 @@ func (s *privilegedDesktopLauncherInternalSuite) TestReadExecCommandFromDesktopF
 	err := ioutil.WriteFile(desktopFile, []byte(chromiumDesktopFile), 0644)
 	c.Assert(err, IsNil)
 
-	_, _, err = userd.ReadExecCommandFromDesktopFile(desktopFile)
+	_, _, err = userd.ReadExecCommandFromDesktopFile(desktopFile, "")
 	c.Assert(err, ErrorMatches, `desktop file ".*" has an unsupported 'Exec' value: .*`)
 }
 
@@ -585,7 +585,7 @@ func (s *privilegedDesktopLauncherInternalSuite) TestReadExecCommandFromDesktopF
 	err := ioutil.WriteFile(desktopFile, []byte(fileContent), 0644)
 	c.Assert(err, IsNil)
 
-	_, _, err = userd.ReadExecCommandFromDesktopFile(desktopFile)
+	_, _, err = userd.ReadExecCommandFromDesktopFile(desktopFile, "")
 	c.Assert(err, ErrorMatches, `desktop file ".*" has an unsupported 'Exec' value: ""`)
 }
 
@@ -598,13 +598,13 @@ Exec=foo
 Exec=bar
 `), 0644), IsNil)
 
-	_, _, err := userd.ReadExecCommandFromDesktopFile(desktopFile)
+	_, _, err := userd.ReadExecCommandFromDesktopFile(desktopFile, "")
 	c.Check(err, ErrorMatches, `desktop file ".*" has multiple \[Desktop Entry\] sections`)
 }
 
 func (s *privilegedDesktopLauncherInternalSuite) TestReadExecCommandFromDesktopFileWithNoFile(c *C) {
 	desktopFile := filepath.Join(c.MkDir(), "test.desktop")
 
-	_, _, err := userd.ReadExecCommandFromDesktopFile(desktopFile)
+	_, _, err := userd.ReadExecCommandFromDesktopFile(desktopFile, "")
 	c.Assert(err, ErrorMatches, `open .*: no such file or directory`)
 }

--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -135,3 +135,10 @@ func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntryFailsForNonSnap(c *
 	err := s.launcher.OpenDesktopEntry("shadow-test.desktop", ":some-dbus-sender")
 	c.Check(err, ErrorMatches, `only launching snap applications from .* is supported`)
 }
+
+func (s *privilegedDesktopLauncherSuite) TestArgumentsSecurity(c *C) {
+	err := userd.ArgumentsSecurityCheck([]string{"param1", "param2"})
+	c.Check(err, IsNil)
+	err = userd.ArgumentsSecurityCheck([]string{"param1", "-param2"})
+	c.Check(err, NotNil)
+}

--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -137,7 +137,7 @@ func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntryFailsForNonSnap(c *
 }
 
 func (s *privilegedDesktopLauncherSuite) TestArgumentsSecurity(c *C) {
-	err := userd.ArgumentsSecurityCheck([]string{"http://param1", "file:///param2.txt"})
+	err := userd.ArgumentsSecurityCheck([]string{"http://param1.com", "file:///param2.txt"})
 	c.Check(err, IsNil)
 	err = userd.ArgumentsSecurityCheck([]string{"-param2"})
 	c.Check(err, NotNil)

--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -137,10 +137,12 @@ func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntryFailsForNonSnap(c *
 }
 
 func (s *privilegedDesktopLauncherSuite) TestArgumentsSecurity(c *C) {
-	err := userd.ArgumentsSecurityCheck([]string{"http://param1.com", "file:///param2.txt"})
+	err := userd.ArgumentsSecurityCheck([]string{"http://param1.com", "file:///param2.txt", "mailto:user@example.org"})
 	c.Check(err, IsNil)
 	err = userd.ArgumentsSecurityCheck([]string{"-param2"})
-	c.Check(err, NotNil)
+	c.Check(err, ErrorMatches, `passed a non-absolute URI: -param2`)
 	err = userd.ArgumentsSecurityCheck([]string{"file://a/test.txt"})
-	c.Check(err, NotNil)
+	c.Check(err, ErrorMatches, `passed a file URI with a non-empty host: file://a/test.txt`)
+	err = userd.ArgumentsSecurityCheck([]string{"file:test.txt"})
+	c.Check(err, ErrorMatches, `passed a file URI with a relative path: file:test.txt`)
 }

--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -137,8 +137,10 @@ func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntryFailsForNonSnap(c *
 }
 
 func (s *privilegedDesktopLauncherSuite) TestArgumentsSecurity(c *C) {
-	err := userd.ArgumentsSecurityCheck([]string{"param1", "param2"})
+	err := userd.ArgumentsSecurityCheck([]string{"http://param1", "file:///param2.txt"})
 	c.Check(err, IsNil)
-	err = userd.ArgumentsSecurityCheck([]string{"param1", "-param2"})
+	err = userd.ArgumentsSecurityCheck([]string{"-param2"})
+	c.Check(err, NotNil)
+	err = userd.ArgumentsSecurityCheck([]string{"file://a/test.txt"})
 	c.Check(err, NotNil)
 }


### PR DESCRIPTION
This is a quick'n'dirty test to check if expanding the DBus method OpenDesktopEntry from io.snapcraft.PrivilegedDesktopLauncher is enough to allow to launch links from Ubuntu Core Desktop.

It seems to work, but it's still incomplete. Things to do:

- manage correctly URIs and files in parseExecCommand, to ensure that %f only gets one file, %u only gets one URI, %F only gets files, and %U only gets URIs.
- add security checks to avoid security holes:
  - copy the checks done by xdg-open
  - if possible, when passing files or file:// URIs, check that the sender has apparmor permissions to read that file?

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
