### PR TITLE
Autoconnect home for core desktop

### DIFF
--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -182,6 +182,12 @@ type OnClassicConstraint struct {
 	SystemIDs []string
 }
 
+// OnCoreDesktopConstraint specifies a constraint based whether the system is core desktop and optional specific distros' sets.
+type OnCoreDesktopConstraint struct {
+	CoreDesktop bool
+	SystemIDs   []string
+}
+
 type nameMatcher interface {
 	match(name string, special map[string]string) error
 }
@@ -304,6 +310,7 @@ type constraintsHolder interface {
 	setAttributeConstraints(field string, cstrs *AttributeConstraints)
 	setIDConstraints(field string, cstrs []string)
 	setOnClassicConstraint(onClassic *OnClassicConstraint)
+	setOnCoreDesktopConstraint(onCoreDesktop *OnCoreDesktopConstraint)
 	setDeviceScopeConstraint(deviceScope *DeviceScopeConstraint)
 }
 
@@ -397,6 +404,31 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 		}
 		target.setOnClassicConstraint(c)
 	}
+	onCoreDesktop := cMap["on-core-desktop"]
+	if onCoreDesktop == nil {
+		defaultUsed++
+	} else {
+		var c *OnCoreDesktopConstraint
+		switch x := onCoreDesktop.(type) {
+		case string:
+			switch x {
+			case "true":
+				c = &OnCoreDesktopConstraint{CoreDesktop: true}
+			case "false":
+				c = &OnCoreDesktopConstraint{CoreDesktop: false}
+			}
+		case []interface{}:
+			lst, err := checkStringListInMap(cMap, "on-core-desktop", fmt.Sprintf("on-core-desktop in %s", context), validDistro)
+			if err != nil {
+				return err
+			}
+			c = &OnCoreDesktopConstraint{CoreDesktop: true, SystemIDs: lst}
+		}
+		if c == nil {
+			return fmt.Errorf("on-core-desktop in %s must be 'true', 'false' or a list of operating system IDs", context)
+		}
+		target.setOnCoreDesktopConstraint(c)
+	}
 	dsc, err := compileDeviceScopeConstraint(cMap, context.String())
 	if err != nil {
 		return err
@@ -408,10 +440,10 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 	}
 	// checks whether defaults have been used for everything, which is not
 	// well-formed
-	// +1+1 accounts for defaults for missing on-classic plus missing
+	// +1+1+1 accounts for defaults for missing on-classic, on-core-desktop plus missing
 	// on-store/on-brand/on-model
-	if defaultUsed == len(nameConstraints)+len(attributeConstraints)+len(idConstraints)+len(sideArityConstraints)+1+1 {
-		return fmt.Errorf("%s must specify at least one of %s, %s, %s, %s, on-classic, on-store, on-brand, on-model", context, strings.Join(nameConstraints, ", "), strings.Join(attrConstraints, ", "), strings.Join(idConstraints, ", "), strings.Join(sideArityConstraints, ", "))
+	if defaultUsed == len(nameConstraints)+len(attributeConstraints)+len(idConstraints)+len(sideArityConstraints)+1+1+1 {
+		return fmt.Errorf("%s must specify at least one of %s, %s, %s, %s, on-classic, on-core-desktop, on-store, on-brand, on-model", context, strings.Join(nameConstraints, ", "), strings.Join(attrConstraints, ", "), strings.Join(idConstraints, ", "), strings.Join(sideArityConstraints, ", "))
 	}
 	return nil
 }
@@ -627,7 +659,8 @@ type PlugInstallationConstraints struct {
 
 	PlugAttributes *AttributeConstraints
 
-	OnClassic *OnClassicConstraint
+	OnClassic     *OnClassicConstraint
+	OnCoreDesktop *OnCoreDesktopConstraint
 
 	DeviceScope *DeviceScopeConstraint
 }
@@ -675,6 +708,10 @@ func (c *PlugInstallationConstraints) setOnClassicConstraint(onClassic *OnClassi
 	c.OnClassic = onClassic
 }
 
+func (c *PlugInstallationConstraints) setOnCoreDesktopConstraint(onCoreDesktop *OnCoreDesktopConstraint) {
+	c.OnCoreDesktop = onCoreDesktop
+}
+
 func (c *PlugInstallationConstraints) setDeviceScopeConstraint(deviceScope *DeviceScopeConstraint) {
 	c.DeviceScope = deviceScope
 }
@@ -709,7 +746,8 @@ type PlugConnectionConstraints struct {
 	// PlugsPerSlot is always * (any) (for now)
 	PlugsPerSlot SideArityConstraint
 
-	OnClassic *OnClassicConstraint
+	OnClassic     *OnClassicConstraint
+	OnCoreDesktop *OnCoreDesktopConstraint
 
 	DeviceScope *DeviceScopeConstraint
 }
@@ -777,6 +815,10 @@ func (c *PlugConnectionConstraints) plugsPerSlot() SideArityConstraint {
 
 func (c *PlugConnectionConstraints) setOnClassicConstraint(onClassic *OnClassicConstraint) {
 	c.OnClassic = onClassic
+}
+
+func (c *PlugConnectionConstraints) setOnCoreDesktopConstraint(onCoreDesktop *OnCoreDesktopConstraint) {
+	c.OnCoreDesktop = onCoreDesktop
 }
 
 func (c *PlugConnectionConstraints) setDeviceScopeConstraint(deviceScope *DeviceScopeConstraint) {
@@ -936,7 +978,8 @@ type SlotInstallationConstraints struct {
 
 	SlotAttributes *AttributeConstraints
 
-	OnClassic *OnClassicConstraint
+	OnClassic     *OnClassicConstraint
+	OnCoreDesktop *OnCoreDesktopConstraint
 
 	DeviceScope *DeviceScopeConstraint
 }
@@ -984,6 +1027,10 @@ func (c *SlotInstallationConstraints) setOnClassicConstraint(onClassic *OnClassi
 	c.OnClassic = onClassic
 }
 
+func (c *SlotInstallationConstraints) setOnCoreDesktopConstraint(onCoreDesktop *OnCoreDesktopConstraint) {
+	c.OnCoreDesktop = onCoreDesktop
+}
+
 func (c *SlotInstallationConstraints) setDeviceScopeConstraint(deviceScope *DeviceScopeConstraint) {
 	c.DeviceScope = deviceScope
 }
@@ -1026,7 +1073,8 @@ type SlotConnectionConstraints struct {
 	// PlugsPerSlot is always * (any) (for now)
 	PlugsPerSlot SideArityConstraint
 
-	OnClassic *OnClassicConstraint
+	OnClassic     *OnClassicConstraint
+	OnCoreDesktop *OnCoreDesktopConstraint
 
 	DeviceScope *DeviceScopeConstraint
 }
@@ -1098,6 +1146,10 @@ func (c *SlotConnectionConstraints) plugsPerSlot() SideArityConstraint {
 
 func (c *SlotConnectionConstraints) setOnClassicConstraint(onClassic *OnClassicConstraint) {
 	c.OnClassic = onClassic
+}
+
+func (c *SlotConnectionConstraints) setOnCoreDesktopConstraint(onCoreDesktop *OnCoreDesktopConstraint) {
+	c.OnCoreDesktop = onCoreDesktop
 }
 
 func (c *SlotConnectionConstraints) setDeviceScopeConstraint(deviceScope *DeviceScopeConstraint) {

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -39,8 +39,6 @@ const homeBaseDeclarationSlots = `
         read: all
     deny-auto-connection:
       -
-        on-classic: false
-      -
         on-core-desktop: false
       -
         plug-attributes:

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -41,6 +41,8 @@ const homeBaseDeclarationSlots = `
       -
         on-classic: false
       -
+        on-core-desktop: false
+      -
         plug-attributes:
           read: all
 `

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -83,6 +83,19 @@ func checkOnClassic(c *asserts.OnClassicConstraint) error {
 	return nil
 }
 
+func checkOnCoreDesktop(c *asserts.OnCoreDesktopConstraint) error {
+	if c == nil {
+		return nil
+	}
+	if c.CoreDesktop != release.OnCoreDesktop {
+		return fmt.Errorf("on-core-desktop mismatch")
+	}
+	if c.CoreDesktop && len(c.SystemIDs) != 0 {
+		return checkID("operating system ID", release.ReleaseInfo.ID, c.SystemIDs, nil)
+	}
+	return nil
+}
+
 func checkDeviceScope(c *asserts.DeviceScopeConstraint, model *asserts.Model, store *asserts.Store) error {
 	if c == nil {
 		return nil
@@ -127,6 +140,9 @@ func checkPlugConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 		"$PLUG_PUBLISHER_ID": connc.plugPublisherID(),
 	})
 	if err != nil {
+		return err
+	}
+	if err := checkOnCoreDesktop(constraints.OnCoreDesktop); err != nil {
 		return err
 	}
 	if err := checkOnClassic(constraints.OnClassic); err != nil {
@@ -179,6 +195,9 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	if err != nil {
 		return err
 	}
+	if err := checkOnCoreDesktop(constraints.OnCoreDesktop); err != nil {
+		return err
+	}
 	if err := checkOnClassic(constraints.OnClassic); err != nil {
 		return err
 	}
@@ -207,6 +226,9 @@ func checkSnapTypeSlotInstallationConstraints1(slot *snap.SlotInfo, constraints 
 	if err := checkSnapType(slot.Snap, constraints.SlotSnapTypes); err != nil {
 		return err
 	}
+	if err := checkOnCoreDesktop(constraints.OnCoreDesktop); err != nil {
+		return err
+	}
 	if err := checkOnClassic(constraints.OnClassic); err != nil {
 		return err
 	}
@@ -218,7 +240,7 @@ func checkMinimalSlotInstallationAltConstraints(slot *snap.SlotInfo, altConstrai
 	var hasSnapTypeConstraints bool
 	// OR of constraints
 	for _, constraints := range altConstraints {
-		if constraints.OnClassic == nil && len(constraints.SlotSnapTypes) == 0 {
+		if constraints.OnClassic == nil && constraints.OnCoreDesktop == nil && len(constraints.SlotSnapTypes) == 0 {
 			continue
 		}
 		hasSnapTypeConstraints = true
@@ -246,6 +268,9 @@ func checkSlotInstallationConstraints1(ic *InstallCandidate, slot *snap.SlotInfo
 		return err
 	}
 	if err := checkID("snap id", ic.snapID(), constraints.SlotSnapIDs, nil); err != nil {
+		return err
+	}
+	if err := checkOnCoreDesktop(constraints.OnCoreDesktop); err != nil {
 		return err
 	}
 	if err := checkOnClassic(constraints.OnClassic); err != nil {
@@ -285,6 +310,9 @@ func checkPlugInstallationConstraints1(ic *InstallCandidate, plug *snap.PlugInfo
 		return err
 	}
 	if err := checkID("snap id", ic.snapID(), constraints.PlugSnapIDs, nil); err != nil {
+		return err
+	}
+	if err := checkOnCoreDesktop(constraints.OnCoreDesktop); err != nil {
 		return err
 	}
 	if err := checkOnClassic(constraints.OnClassic); err != nil {


### PR DESCRIPTION
This makes home autoconnect on core desktop. Due to the way snapd checks interface rules, checking `on-classic` stops any further checks. For this reason this patch needs work before it can be applied in upstream snapd. Proposing now so we can make use of this feature in core desktop now.