### PR TITLE
wrappers: ensure /var/lib/snapd/desktop/applications exists in writeSnapdDesktopFilesOnCore

### DIFF
--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -676,6 +676,11 @@ func getSnapdDesktopFileNames(s *snap.Info) ([]string, error) {
 }
 
 func writeSnapdDesktopFilesOnCore(s *snap.Info) error {
+	// Ensure /var/lib/snapd/desktop/applications exists
+	if err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755); err != nil {
+		return err
+	}
+
 	desktopFileNames, err := getSnapdDesktopFileNames(s)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is a test to see if it fixes  the seeding problem. The theory is that `writeSnapdDesktopFilesOnCore` is failing because `/var/lib/snapd/desktop/applications` does not exist when it tries to copy some files there. So we ensure it exists.