### PR TITLE
interfaces: update desktop slot for gnome-shell 45

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -384,6 +384,14 @@ dbus (send)
     member="Get{,All}"
     peer=(label=unconfined),
 
+# Allow gnome-shell to bind to its various D-Bus names
+dbus (bind)
+    bus=session
+    name=org.gnome.Mutter.*,
+dbus (bind)
+    bus=session
+    name=org.gnome.Shell{,.*},
+
 # Allow access to GDM's private reauthentication channel socket
 unix (connect, receive, send)
     type=stream

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -392,6 +392,19 @@ dbus (bind)
     bus=session
     name=org.gnome.Shell{,.*},
 
+# Allow the shell to communicate with colord
+dbus (send, receive)
+    bus=system
+    path=/org/freedesktop/ColorManager{,/**}
+    interface=org.freedesktop.ColorManager*
+    peer=(label=unconfined),
+dbus (send, receive)
+    bus=system
+    path=/org/freedesktop/ColorManager{,/**}
+    interface=org.freedesktop.DBus.Properties
+    member={Get,GetAll,PropertiesChanged}
+    peer=(label=unconfined),
+
 # Allow access to GDM's private reauthentication channel socket
 unix (connect, receive, send)
     type=stream


### PR DESCRIPTION
* Allow gnome-shell to bind to `org.gnome.Mutter.*`, `org.gnome.Shell`, and `org.gnome.Shell.*` D-Bus names. This is mainly to support the new `org.gnome.Mutter.ServiceChannel` name, but could probably replace any of the covered ubuntu-desktop-session slots we're not using for D-Bus activation.
* Allow communication with colord on the system bus. gnome-shell tries to communicate with it synchronously, so blocking these messages results in a long timeout during login.