### PR TITLE
interfaces: update permanent slot rules to allow all connections on abstract X11 socket

### DIFF
--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -74,6 +74,13 @@ unix (bind, listen, accept)
      type=stream
      addr="@/tmp/.ICE-unix/[0-9]*",
 
+# Allow all connections to the X11 socket
+# NOTE: This is a temporary work around until the kernel bug
+# preventing proper rule replacement on the socket is fixed.
+unix (connect, receive, send, accept)
+    type=stream
+    addr="@/tmp/.X11-unix/X[0-9]*",
+
 # On systems with Tegra drivers, X11 needs to create the socket for clients to
 # use.
 unix (bind, listen, accept)


### PR DESCRIPTION
This is a temporary workaround for the AppArmor rules affecting the socket not being properly replaced.

The nature of the kernel bug is outlined here: https://gist.github.com/jhenstridge/5b94e9aec93398534f5459dd0f66f294

This change should not be upstreamed to snapd, and should be backed out once the kernel is patched.