### PR TITLE
interfaces: add support for snapped pipewire

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -247,7 +247,7 @@ parts:
       if [ -f test-build ]; then
           VERSION="1337.${VERSION}"
       fi
-      VERSION="$(echo $VERSION | fold -w 32 |head -n 1)"
+      VERSION="$(echo $VERSION | cut -c1-32)"
       craftctl set version="$VERSION"
 
       ./get-deps.sh --skip-unused-check

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -247,6 +247,7 @@ parts:
       if [ -f test-build ]; then
           VERSION="1337.${VERSION}"
       fi
+      VERSION="$(echo $VERSION | fold -w 32 |head -n 1)"
       craftctl set version="$VERSION"
 
       ./get-deps.sh --skip-unused-check

--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -116,9 +116,7 @@ owner /{,var/}run/pulse/** rwk,
 
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pulse/ rw,
-
-# This allows to share screen in Core Desktop
-owner /run/user/[0-9]*/pipewire-[0-9] rwk,
+owner /run/user/[0-9]*/pulse/** rw,
 
 # This allows wireplumber to read the pulseaudio
 # configuration if pipewire runs inside a container

--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -37,14 +37,11 @@ const pipewireBaseDeclarationSlots = `
         - app
         - core
     deny-auto-connection: true
-	deny-connection:
+    deny-connection:
       on-classic: false
 `
 
 const pipewireConnectedPlugAppArmor = `
-# Allow communicating with pipewire service
-/{run,dev}/shm/pulse-shm-* mrwk,
-
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pipewire-[0-9] rw,
 `
@@ -58,9 +55,6 @@ shmctl
 `
 
 const pipewirePermanentSlotAppArmor = `
-capability sys_nice,
-capability sys_resource,
-
 owner @{PROC}/@{pid}/exe r,
 
 # For udev
@@ -68,9 +62,6 @@ network netlink raw,
 /sys/devices/virtual/dmi/id/sys_vendor r,
 /sys/devices/virtual/dmi/id/bios_vendor r,
 /sys/**/sound/** r,
-
-# Shared memory based communication with clients
-/{run,dev}/shm/pulse-shm-* mrwk,
 
 owner /run/user/[0-9]*/pipewire-[0-9] rwk,
 owner /run/user/[0-9]*/pipewire-[0-9]-manager rwk,
@@ -112,10 +103,6 @@ func (iface *pipewireInterface) AppArmorPermanentSlot(spec *apparmor.Specificati
 func (iface *pipewireInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(pipewirePermanentSlotSecComp)
 	return nil
-}
-
-func (iface *pipewireInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
-	return true
 }
 
 func init() {

--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -35,6 +35,7 @@ const pipewireBaseDeclarationSlots = `
     allow-installation:
       slot-snap-type:
         - app
+        - core
     deny-auto-connection: true
 	deny-connection:
       on-classic: false

--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -46,12 +46,10 @@ const pipewireConnectedPlugAppArmor = `
 
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pipewire-[0-9] rw,
-owner /run/user/[0-9]*/pipewire-[0-9]-manager rw,
 `
 
 const pipewireConnectedPlugAppArmorCore = `
 owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pipewire-[0-9] rw,
-owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pipewire-[0-9]-manager rw,
 `
 
 const pipewireConnectedPlugSecComp = `

--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -36,6 +36,8 @@ const pipewireBaseDeclarationSlots = `
       slot-snap-type:
         - app
     deny-auto-connection: true
+	deny-connection:
+      on-classic: false
 `
 
 const pipewireConnectedPlugAppArmor = `
@@ -44,10 +46,12 @@ const pipewireConnectedPlugAppArmor = `
 
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pipewire-[0-9] rw,
+owner /run/user/[0-9]*/pipewire-[0-9]-manager rw,
 `
 
 const pipewireConnectedPlugAppArmorCore = `
 owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pipewire-[0-9] rw,
+owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pipewire-[0-9]-manager rw,
 `
 
 const pipewireConnectedPlugSecComp = `
@@ -59,7 +63,6 @@ capability sys_nice,
 capability sys_resource,
 
 owner @{PROC}/@{pid}/exe r,
-/etc/machine-id r,
 
 # For udev
 network netlink raw,
@@ -87,19 +90,8 @@ shmctl
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
-type pipewireInterface struct{}
-
-func (iface *pipewireInterface) Name() string {
-	return "pipewire"
-}
-
-func (iface *pipewireInterface) StaticInfo() interfaces.StaticInfo {
-	return interfaces.StaticInfo{
-		Summary:              pipewireSummary,
-		ImplicitOnClassic:    false,
-		ImplicitOnCore:       false,
-		BaseDeclarationSlots: pipewireBaseDeclarationSlots,
-	}
+type pipewireInterface struct {
+	commonInterface
 }
 
 func (iface *pipewireInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
@@ -118,11 +110,6 @@ func (iface *pipewireInterface) AppArmorPermanentSlot(spec *apparmor.Specificati
 	return nil
 }
 
-func (iface *pipewireInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	spec.AddSnippet(pipewireConnectedPlugSecComp)
-	return nil
-}
-
 func (iface *pipewireInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(pipewirePermanentSlotSecComp)
 	return nil
@@ -133,5 +120,12 @@ func (iface *pipewireInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool
 }
 
 func init() {
-	registerIface(&pipewireInterface{})
+	registerIface(&pipewireInterface{commonInterface: commonInterface{
+		name:                 "pipewire",
+		summary:              pipewireSummary,
+		implicitOnCore:       false,
+		implicitOnClassic:    true,
+		baseDeclarationSlots: pipewireBaseDeclarationSlots,
+		connectedPlugSecComp: pipewireConnectedPlugSecComp,
+	}})
 }

--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -1,0 +1,137 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+)
+
+const pipewireSummary = `allows access to the pipewire sockets, and offer them`
+
+const pipewireBaseDeclarationSlots = `
+  pipewire:
+    allow-installation:
+      slot-snap-type:
+        - app
+    deny-auto-connection: true
+`
+
+const pipewireConnectedPlugAppArmor = `
+# Allow communicating with pipewire service
+/{run,dev}/shm/pulse-shm-* mrwk,
+
+owner /run/user/[0-9]*/ r,
+owner /run/user/[0-9]*/pipewire-[0-9] rw,
+`
+
+const pipewireConnectedPlugAppArmorCore = `
+owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pipewire-[0-9] rw,
+`
+
+const pipewireConnectedPlugSecComp = `
+shmctl
+`
+
+const pipewirePermanentSlotAppArmor = `
+capability sys_nice,
+capability sys_resource,
+
+owner @{PROC}/@{pid}/exe r,
+/etc/machine-id r,
+
+# For udev
+network netlink raw,
+/sys/devices/virtual/dmi/id/sys_vendor r,
+/sys/devices/virtual/dmi/id/bios_vendor r,
+/sys/**/sound/** r,
+
+# Shared memory based communication with clients
+/{run,dev}/shm/pulse-shm-* mrwk,
+
+owner /run/user/[0-9]*/pipewire-[0-9] rwk,
+owner /run/user/[0-9]*/pipewire-[0-9]-manager rwk,
+`
+
+const pipewirePermanentSlotSecComp = `
+# The following are needed for UNIX sockets
+personality
+setpriority
+bind
+listen
+accept
+accept4
+shmctl
+# libudev
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
+`
+
+type pipewireInterface struct{}
+
+func (iface *pipewireInterface) Name() string {
+	return "pipewire"
+}
+
+func (iface *pipewireInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              pipewireSummary,
+		ImplicitOnClassic:    false,
+		ImplicitOnCore:       false,
+		BaseDeclarationSlots: pipewireBaseDeclarationSlots,
+	}
+}
+
+func (iface *pipewireInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.AddSnippet(pipewireConnectedPlugAppArmor)
+	if !implicitSystemConnectedSlot(slot) {
+		old := "###SLOT_SECURITY_TAGS###"
+		new := "snap." + slot.Snap().InstanceName() // forms the snap-instance-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
+		snippet := strings.Replace(pipewireConnectedPlugAppArmorCore, old, new, -1)
+		spec.AddSnippet(snippet)
+	}
+	return nil
+}
+
+func (iface *pipewireInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
+	spec.AddSnippet(pipewirePermanentSlotAppArmor)
+	return nil
+}
+
+func (iface *pipewireInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.AddSnippet(pipewireConnectedPlugSecComp)
+	return nil
+}
+
+func (iface *pipewireInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *snap.SlotInfo) error {
+	spec.AddSnippet(pipewirePermanentSlotSecComp)
+	return nil
+}
+
+func (iface *pipewireInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
+	return true
+}
+
+func init() {
+	registerIface(&pipewireInterface{})
+}

--- a/interfaces/builtin/pipewire_test.go
+++ b/interfaces/builtin/pipewire_test.go
@@ -144,7 +144,6 @@ func (s *pipewireInterfaceSuite) TestAppArmor(c *C) {
 	spec := apparmor.NewSpecification(s.plug.AppSet())
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9] rw,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rw,\n")
 
@@ -169,7 +168,6 @@ func (s *pipewireInterfaceSuite) TestAppArmorOnClassic(c *C) {
 	spec := apparmor.NewSpecification(s.plug.AppSet())
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rw,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9] rw,\n")
 

--- a/interfaces/builtin/pipewire_test.go
+++ b/interfaces/builtin/pipewire_test.go
@@ -20,11 +20,8 @@
 package builtin_test
 
 import (
-	"fmt"
-
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -35,7 +32,7 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type AudioPlaybackInterfaceSuite struct {
+type pipewireInterfaceSuite struct {
 	iface           interfaces.Interface
 	coreSlotInfo    *snap.SlotInfo
 	coreSlot        *interfaces.ConnectedSlot
@@ -45,56 +42,56 @@ type AudioPlaybackInterfaceSuite struct {
 	plug            *interfaces.ConnectedPlug
 }
 
-var _ = Suite(&AudioPlaybackInterfaceSuite{
-	iface: builtin.MustInterface("audio-playback"),
+var _ = Suite(&pipewireInterfaceSuite{
+	iface: builtin.MustInterface("pipewire"),
 })
 
-const audioPlaybackMockPlugSnapInfoYaml = `name: consumer
+const pipewireMockPlugSnapInfoYaml = `name: consumer
 version: 1.0
 apps:
  app:
   command: foo
-  plugs: [audio-playback]
+  plugs: [pipewire]
 `
 
-// a audio-playback slot on a audio-playback snap (as installed on a core/all-snap system)
-const audioPlaybackMockCoreSlotSnapInfoYaml = `name: audio-playback
+// a pipewire slot on a pipewire snap (as installed on a core/all-snap system)
+const pipewireMockCoreSlotSnapInfoYaml = `name: pipewire
 version: 1.0
 apps:
  app1:
   command: foo
-  slots: [audio-playback]
+  slots: [pipewire]
 `
 
-// a audio-playback slot on the core snap (as automatically added on classic)
-const audioPlaybackMockClassicSlotSnapInfoYaml = `name: core
+// a pipewire slot on the core snap (as automatically added on classic)
+const pipewireMockClassicSlotSnapInfoYaml = `name: core
 version: 0
 type: os
 slots:
- audio-playback:
-  interface: audio-playback
+ pipewire:
+  interface: pipewire
 `
 
-func (s *AudioPlaybackInterfaceSuite) SetUpTest(c *C) {
-	s.coreSlot, s.coreSlotInfo = MockConnectedSlot(c, audioPlaybackMockCoreSlotSnapInfoYaml, nil, "audio-playback")
-	s.classicSlot, s.classicSlotInfo = MockConnectedSlot(c, audioPlaybackMockClassicSlotSnapInfoYaml, nil, "audio-playback")
-	s.plug, s.plugInfo = MockConnectedPlug(c, audioPlaybackMockPlugSnapInfoYaml, nil, "audio-playback")
+func (s *pipewireInterfaceSuite) SetUpTest(c *C) {
+	s.coreSlot, s.coreSlotInfo = MockConnectedSlot(c, pipewireMockCoreSlotSnapInfoYaml, nil, "pipewire")
+	s.classicSlot, s.classicSlotInfo = MockConnectedSlot(c, pipewireMockClassicSlotSnapInfoYaml, nil, "pipewire")
+	s.plug, s.plugInfo = MockConnectedPlug(c, pipewireMockPlugSnapInfoYaml, nil, "pipewire")
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestName(c *C) {
-	c.Assert(s.iface.Name(), Equals, "audio-playback")
+func (s *pipewireInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "pipewire")
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestSanitizeSlot(c *C) {
+func (s *pipewireInterfaceSuite) TestSanitizeSlot(c *C) {
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.coreSlotInfo), IsNil)
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.classicSlotInfo), IsNil)
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestSanitizePlug(c *C) {
+func (s *pipewireInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestSecComp(c *C) {
+func (s *pipewireInterfaceSuite) TestSecComp(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
@@ -112,11 +109,11 @@ func (s *AudioPlaybackInterfaceSuite) TestSecComp(c *C) {
 	// permanent core slot
 	spec = seccomp.NewSpecification(s.coreSlot.AppSet())
 	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
-	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.audio-playback.app1"})
-	c.Assert(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "listen\n")
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.pipewire.app1"})
+	c.Assert(spec.SnippetForTag("snap.pipewire.app1"), testutil.Contains, "listen\n")
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestSecCompOnClassic(c *C) {
+func (s *pipewireInterfaceSuite) TestSecCompOnClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -126,9 +123,9 @@ func (s *AudioPlaybackInterfaceSuite) TestSecCompOnClassic(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shmctl\n")
 
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/ r,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/native rwk,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/pid r,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pulse/ r,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pulse/native rwk,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pulse/pid r,\n")
 
 	// connected classic slot to plug
 	spec = seccomp.NewSpecification(s.classicSlot.AppSet())
@@ -140,11 +137,10 @@ func (s *AudioPlaybackInterfaceSuite) TestSecCompOnClassic(c *C) {
 	c.Assert(spec.AddPermanentSlot(s.iface, s.classicSlotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), HasLen, 0)
 
-	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), Not(testutil.Contains), "/etc/pulse/ r,\n")
-	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), Not(testutil.Contains), "/etc/pulse/** r,\n")
+	c.Assert(spec.SnippetForTag("snap.pipewire.app1"), Not(testutil.Contains), "owner /run/user/[0-9]*/pipewire-[0-9] rwk,\n")
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
+func (s *pipewireInterfaceSuite) TestAppArmor(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
@@ -153,9 +149,7 @@ func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/ r,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/native rwk,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/pid r,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9] rw,\n")
 
 	// connected core slot to plug
 	spec = apparmor.NewSpecification(s.coreSlot.AppSet())
@@ -165,13 +159,12 @@ func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
 	// permanent core slot
 	spec = apparmor.NewSpecification(s.coreSlot.AppSet())
 	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
-	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.audio-playback.app1"})
-	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "capability setuid,\n")
-	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "/etc/pulse/ r,\n")
-	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "/etc/pulse/** r,\n")
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.pipewire.app1"})
+	c.Assert(spec.SnippetForTag("snap.pipewire.app1"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rwk,\n")
+	c.Assert(spec.SnippetForTag("snap.pipewire.app1"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9]-manager rwk,\n")
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestAppArmorOnClassic(c *C) {
+func (s *pipewireInterfaceSuite) TestAppArmorOnClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -180,7 +173,7 @@ func (s *AudioPlaybackInterfaceSuite) TestAppArmorOnClassic(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/etc/pulse/ r,\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rw,\n")
 
 	// connected classic slot to plug
 	spec = apparmor.NewSpecification(s.classicSlot.AppSet())
@@ -193,19 +186,12 @@ func (s *AudioPlaybackInterfaceSuite) TestAppArmorOnClassic(c *C) {
 	c.Assert(spec.SecurityTags(), HasLen, 0)
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestUDev(c *C) {
+func (s *pipewireInterfaceSuite) TestUDev(c *C) {
 	spec := udev.NewSpecification(s.coreSlot.AppSet())
 	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 4)
-	c.Assert(spec.Snippets(), testutil.Contains, `# audio-playback
-KERNEL=="controlC[0-9]*", TAG+="snap_audio-playback_app1"`)
-	c.Assert(spec.Snippets(), testutil.Contains, `# audio-playback
-KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="snap_audio-playback_app1"`)
-	c.Assert(spec.Snippets(), testutil.Contains, `# audio-playback
-KERNEL=="timer", TAG+="snap_audio-playback_app1"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_audio-playback_app1", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_audio-playback_app1 $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), HasLen, 0)
 }
 
-func (s *AudioPlaybackInterfaceSuite) TestInterfaces(c *C) {
+func (s *pipewireInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }

--- a/interfaces/builtin/pipewire_test.go
+++ b/interfaces/builtin/pipewire_test.go
@@ -146,9 +146,7 @@ func (s *pipewireInterfaceSuite) TestAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9] rw,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9]-manager rw,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rw,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9]-manager rw,\n")
 
 	// connected core slot to plug
 	spec = apparmor.NewSpecification(s.coreSlot.AppSet())
@@ -173,9 +171,7 @@ func (s *pipewireInterfaceSuite) TestAppArmorOnClassic(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rw,\n")
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9]-manager rw,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9] rw,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9]-manager rw,\n")
 
 	// connected classic slot to plug
 	spec = apparmor.NewSpecification(s.classicSlot.AppSet())

--- a/interfaces/builtin/pipewire_test.go
+++ b/interfaces/builtin/pipewire_test.go
@@ -123,10 +123,6 @@ func (s *pipewireInterfaceSuite) TestSecCompOnClassic(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shmctl\n")
 
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pulse/ r,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pulse/native rwk,\n")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pulse/pid r,\n")
-
 	// connected classic slot to plug
 	spec = seccomp.NewSpecification(s.classicSlot.AppSet())
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.classicSlot), IsNil)
@@ -150,6 +146,9 @@ func (s *pipewireInterfaceSuite) TestAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9] rw,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9]-manager rw,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rw,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9]-manager rw,\n")
 
 	// connected core slot to plug
 	spec = apparmor.NewSpecification(s.coreSlot.AppSet())
@@ -174,6 +173,9 @@ func (s *pipewireInterfaceSuite) TestAppArmorOnClassic(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rw,\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9]-manager rw,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9] rw,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.pipewire/pipewire-[0-9]-manager rw,\n")
 
 	// connected classic slot to plug
 	spec = apparmor.NewSpecification(s.classicSlot.AppSet())

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -862,6 +862,7 @@ var (
 		"network-status":            {"core"},
 		"ofono":                     {"app", "core"},
 		"online-accounts-service":   {"app"},
+		"pipewire":                  {"app"},
 		"power-control":             {"core"},
 		"ppp":                       {"core"},
 		"polkit-agent":              {"core"},

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -862,7 +862,7 @@ var (
 		"network-status":            {"core"},
 		"ofono":                     {"app", "core"},
 		"online-accounts-service":   {"app"},
-		"pipewire":                  {"app"},
+		"pipewire":                  {"app", "core"},
 		"power-control":             {"core"},
 		"ppp":                       {"core"},
 		"polkit-agent":              {"core"},

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -188,6 +188,9 @@ apps:
   physical-memory-control:
     command: bin/run
     plugs: [ physical-memory-control ]
+  pipewire:
+    command: bin/run
+    plugs: [ pipewire ]
   pkcs11:
     command: bin/run
     plugs: [ pkcs11 ]


### PR DESCRIPTION
This MR implements the pipewire interface, to allow a snap to have full access to /run/user/XXXX/pipewire-0 and pipewire-0-manager paths, to allow to create the pipewire sockets in the global XDG_RUNTIME_DIR. Also gives permissions to create the same in the pulse/ folder in the audio-playback slot.

It is also sent to upstream at https://github.com/canonical/snapd/pull/14453 , but still marked as draft until this one is reviewed, approved and merged.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
