### PR TITLE
Add access to /etc/xdg/Xwayland-session.d

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -630,6 +630,7 @@ dbus (send)
 /etc/xdg/autostart{,/**} r,
 /etc/xdg/user-dirs.conf r,
 /etc/xdg/user-dirs.defaults r,
+/etc/xdg/Xwayland-session.d{,**} r,
 /run/udev/tags/seat{,/**} r,
 
 # KDE Plasma specific extension


### PR DESCRIPTION
This seems required for XWayland. Without it, an error is shown in journalctl when launching XWayland.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
