### PR TITLE
desktopInterface: Add StartTransientUnit to desktop slot

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -550,6 +550,13 @@ dbus (send)
     member="Get{,All}"
     peer=(label=unconfined),
 
+dbus (send)
+    bus=session
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member={StartTransientUnit,StopUnit}
+    peer=(label=unconfined),
+
 # Allow access to GDM's private reauthentication channel socket
 /run/gdm3/dbus/dbus-* rw,
 


### PR DESCRIPTION
This systemd method is required by Gnome Shell to launch some services.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
