### PR TITLE
pipewire: add access to xdg-permission-store from pipewire

### DIFF
--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -65,6 +65,28 @@ network netlink raw,
 
 owner /run/user/[0-9]*/pipewire-[0-9] rwk,
 owner /run/user/[0-9]*/pipewire-[0-9]-manager rwk,
+
+# Access to xdg-permission-store
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.impl.portal.PermissionStore
+    path=/org/freedesktop/impl/portal/PermissionStore
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/freedesktop/impl/portal/PermissionStore
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.DBus.Peer
+    path=/org/freedesktop/impl/portal/PermissionStore
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.DBus.Introspectable
+    path=/org/freedesktop/impl/portal/PermissionStore
+    peer=(label=unconfined),
 `
 
 const pipewirePermanentSlotSecComp = `


### PR DESCRIPTION
This is needed for wireplumber.

upstream PR: https://github.com/canonical/snapd/pull/15338

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
