### PR TITLE
interfaces: Allow installing systemd-user-control interface

### DIFF
--- a/interfaces/builtin/systemd_user_control.go
+++ b/interfaces/builtin/systemd_user_control.go
@@ -23,7 +23,7 @@ const systemdUserControlSummary = `allows to control the user session service ma
 
 const systemdUserControlBaseDeclarationPlugs = `
   systemd-user-control:
-    allow-installation: false
+    allow-installation: true
     deny-auto-connection: true
 `
 

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1064,7 +1064,6 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 		"snapd-control":                    true,
 		"steam-support":                    true,
 		"system-files":                     true,
-		"systemd-user-control":             true,
 		"tee":                              true,
 		"uinput":                           true,
 		"unity8":                           true,


### PR DESCRIPTION
This is necessary to be able to install plasma-desktop-session from the store as the store declaration doesn't mention systemd-user-control at all.
