### PR TITLE
CI: Fix github CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
             variant: pristine
 
   cache-build-deps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -164,7 +164,7 @@ jobs:
 
   code-coverage:
     needs: [unit-tests, unit-tests-special]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GOPATH: ${{ github.workspace }}
       # Set PATH to ignore the load of magic binaries from /usr/local/bin And


### PR DESCRIPTION
This patch changes ubuntu-20.04 with ubuntu-latest to ensure that the CI works again, because recently ubuntu-20.04 runner was removed due to being deprecated.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
