### PR TITLE
udisks2: Add chmod support for udisks2

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -126,6 +126,8 @@ umount /{,run/}media/**,
 
 # Needed for probing raw devices
 capability sys_rawio,
+# And chown to be able to set permissions in folders created at /media
+capability chown,
 
 /run/ rw,
 /run/cryptsetup/{,**} rwk,
@@ -219,6 +221,7 @@ dbus (send)
 
 const udisks2PermanentSlotSecComp = `
 bind
+chown
 chown32
 fchown
 fchown32


### PR DESCRIPTION
When mounting a partition from udisks2 as a non-root user, it fails because it can't change the group to the /media/XXXXX folder.

This patch fixes this.

upstream patch: https://github.com/canonical/snapd/pull/15432

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
